### PR TITLE
create-effect-migration was moved into ng-update

### DIFF
--- a/content/blog/ngrx-creator-functions-101/index.md
+++ b/content/blog/ngrx-creator-functions-101/index.md
@@ -544,7 +544,7 @@ There's a schematic to convert all the `@Effect` decorators to the `createEffect
 # version 12 or erlier
 ng generate @ngrx/schematics:create-effect-migration
 
-// version 13 or later
+# version 13 or later
 ng update @ngrx/effects --from 12 --to 13 --migrate-only
 ```
 

--- a/content/blog/ngrx-creator-functions-101/index.md
+++ b/content/blog/ngrx-creator-functions-101/index.md
@@ -541,7 +541,7 @@ See the Pull Requests [ROOT_EFFECTS_INIT actions as ActionCreators - by Sam Lin]
 There's a schematic to convert all the `@Effect` decorators to the `createEffect` function, run the following command to run the schematic:
 
 ```bash
-// version 12 or erlier
+# version 12 or erlier
 ng generate @ngrx/schematics:create-effect-migration
 
 // version 13 or later

--- a/content/blog/ngrx-creator-functions-101/index.md
+++ b/content/blog/ngrx-creator-functions-101/index.md
@@ -541,7 +541,11 @@ See the Pull Requests [ROOT_EFFECTS_INIT actions as ActionCreators - by Sam Lin]
 There's a schematic to convert all the `@Effect` decorators to the `createEffect` function, run the following command to run the schematic:
 
 ```bash
+// version 12 or erlier
 ng generate @ngrx/schematics:create-effect-migration
+
+// version 13 or later
+ng update @ngrx/effects --from 12 --to 13 --migrate-only
 ```
 
 The [NgRx Schematics](https://ngrx.io/guide/schematics/install) has to be installed to run the command.

--- a/content/blog/ngrx-creator-functions-101/index.md
+++ b/content/blog/ngrx-creator-functions-101/index.md
@@ -541,11 +541,11 @@ See the Pull Requests [ROOT_EFFECTS_INIT actions as ActionCreators - by Sam Lin]
 There's a schematic to convert all the `@Effect` decorators to the `createEffect` function, run the following command to run the schematic:
 
 ```bash
-# version 12 or erlier
-ng generate @ngrx/schematics:create-effect-migration
-
 # version 13 or later
 ng update @ngrx/effects --from 12 --to 13 --migrate-only
+
+# version 12 or earlier
+ng generate @ngrx/schematics:create-effect-migration
 ```
 
 The [NgRx Schematics](https://ngrx.io/guide/schematics/install) has to be installed to run the command.


### PR DESCRIPTION
Explains how to run the create-effect-migration depending on the ngrx version, since it changed with v13.