### PR TITLE
update syntax for ng cli boolean options

### DIFF
--- a/blog/common-and-easy-to-make-mistakes-when-youre-new-to-ngrx/index.md
+++ b/blog/common-and-easy-to-make-mistakes-when-youre-new-to-ngrx/index.md
@@ -28,7 +28,7 @@ Let’s get started! We can create the project using the `ng new` command and we
 ```bash
 ng new ngrx-fizzbuzz
 ng add @ngrx/store
-ng add @ngrx/effects --spec=false --group=true
+ng add @ngrx/effects --no-spec --group
 ng add @ngrx/store-devtools
 yarn add @ngrx/schematics --dev
 ```


### PR DESCRIPTION
Hi @timdeschryver , 

Angular 15 CLI no longer accepts `--spec=false --group=true` for `ng add @ngrx/effects`, I get a schema validation error when I try that; this PR changes the code example according to https://angular.io/cli#boolean-options, works for me.

Cheers, Christian
