### PR TITLE
Added a reference to Angular Change Detection in 5 minutes video

### DIFF
--- a/blog/help-angular-to-make-your-application-faster/index.md
+++ b/blog/help-angular-to-make-your-application-faster/index.md
@@ -30,7 +30,9 @@ After a few `console.log` statements inside the [`OnChanges` lifecycle hook](htt
 
 We already had the `ChangeDetectionStrategy` of all of our components to [`ChangeDetectionStrategy.OnPush`](https://angular.io/api/core/ChangeDetectionStrategy#OnPush), and we're already using pure pipes in multiple places of our application.
 These good practices took us far, but not far enough later on in the development phase.
-If you don't know how Change Detection in Angular works, [this video explains it in 5 minutes](https://blog.simplified.courses/angular-change-detection-explained-in-5-minutes/){:target="_blank"}
+:::info
+If you don't know how Change Detection in Angular works, [this video explains it in 5 minutes](https://blog.simplified.courses/angular-change-detection-explained-in-5-minutes/)
+:::
 
 ## Solutions <!-- omit in toc -->
 

--- a/blog/help-angular-to-make-your-application-faster/index.md
+++ b/blog/help-angular-to-make-your-application-faster/index.md
@@ -30,6 +30,7 @@ After a few `console.log` statements inside the [`OnChanges` lifecycle hook](htt
 
 We already had the `ChangeDetectionStrategy` of all of our components to [`ChangeDetectionStrategy.OnPush`](https://angular.io/api/core/ChangeDetectionStrategy#OnPush), and we're already using pure pipes in multiple places of our application.
 These good practices took us far, but not far enough later on in the development phase.
+If you don't know how Change Detection in Angular works, [this video explains it in 5 minutes](https://blog.simplified.courses/angular-change-detection-explained-in-5-minutes/){:target="_blank"}
 
 ## Solutions <!-- omit in toc -->
 


### PR DESCRIPTION
I have added a reference to https://blog.simplified.courses/angular-change-detection-explained-in-5-minutes/ because I think it would help people understand this article better in a very limited time (5 minutes). I added the target as `_blank`, so the original article is not affected